### PR TITLE
Add situation engine integration

### DIFF
--- a/src/call_handler.py
+++ b/src/call_handler.py
@@ -7,9 +7,16 @@ import requests
 from .audio_player import play_wav
 from .vad_recorder import record_until_silence
 from .memory_logger import log_interaction
+from .situation_generator import generate_situation
 
 
-def handle_call(temp_dir: Path, server_url: str, personality_id: str, memory_dir: Path | None = None) -> None:
+def handle_call(
+    temp_dir: Path,
+    server_url: str,
+    personality_id: str,
+    memory_dir: Path | None = None,
+    personality_prompt: str | None = None,
+) -> None:
     """Record caller audio, send it for processing, and play the response.
 
     Parameters
@@ -20,16 +27,29 @@ def handle_call(temp_dir: Path, server_url: str, personality_id: str, memory_dir
         Base URL of the LLM processing server.
     memory_dir:
         Optional directory for storing interaction logs.
+    personality_prompt:
+        Optional prompt text used to generate a call situation.
     """
+
+    situation: str | None = None
+    if personality_prompt is not None:
+        try:
+            situation = generate_situation(server_url, personality_id, [], personality_prompt)
+        except Exception:
+            situation = None
 
     recorded = temp_dir / "caller.wav"
     record_until_silence(recorded)
 
     with recorded.open("rb") as fh:
+        data = {"character_id": personality_id}
+        if situation:
+            data["situation"] = situation
+
         response = requests.post(
             f"{server_url}/process-audio",
             files={"audio_file": fh},
-            data={"character_id": personality_id},
+            data=data,
         )
         response.raise_for_status()
 

--- a/src/situation_generator.py
+++ b/src/situation_generator.py
@@ -1,0 +1,30 @@
+"""Generate call situations using remote LLM server."""
+from __future__ import annotations
+
+from typing import List
+import requests
+
+
+def generate_situation(server_url: str, character_id: str, memory_snippets: List[str], personality_prompt: str) -> str:
+    """Request a situation from the LLM server.
+
+    Parameters
+    ----------
+    server_url:
+        Base URL of the LLM server.
+    character_id:
+        Identifier for the personality.
+    memory_snippets:
+        Recent memory snippets for context.
+    personality_prompt:
+        The personality's base prompt text.
+    """
+    payload = {
+        "character_id": character_id,
+        "memory_snippets": memory_snippets,
+        "personality_prompt": personality_prompt,
+    }
+    response = requests.post(f"{server_url}/generate-situation", json=payload)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("situation", "")

--- a/tests/test_call_flow.py
+++ b/tests/test_call_flow.py
@@ -23,3 +23,35 @@ def test_handle_call(tmp_path):
         post.assert_called_once()
         play.assert_called_once_with(response_path)
         log.assert_called_once()
+
+
+def test_handle_call_with_situation(tmp_path):
+    record_path = tmp_path / "caller.wav"
+    response_path = tmp_path / "response.wav"
+
+    with mock.patch("src.call_handler.record_until_silence") as rec, \
+         mock.patch("src.call_handler.play_wav") as play, \
+         mock.patch("src.call_handler.log_interaction") as log, \
+         mock.patch("src.call_handler.generate_situation") as gen, \
+         mock.patch("requests.post") as post:
+        rec.side_effect = lambda p: Path(p).write_bytes(b"caller")
+        gen.return_value = "a scene"
+        post.return_value.status_code = 200
+        post.return_value.content = b"wavdata"
+        post.return_value.raise_for_status = lambda: None
+
+        handle_call(
+            tmp_path,
+            "http://server",
+            "captain",
+            tmp_path,
+            personality_prompt="prompt",
+        )
+
+        rec.assert_called_once_with(record_path)
+        gen.assert_called_once()
+        post.assert_called_once()
+        args, kwargs = post.call_args
+        assert kwargs["data"]["situation"] == "a scene"
+        play.assert_called_once_with(response_path)
+        log.assert_called_once()

--- a/tests/test_situation_generator.py
+++ b/tests/test_situation_generator.py
@@ -1,0 +1,17 @@
+from src.situation_generator import generate_situation
+from unittest import mock
+
+
+def test_generate_situation():
+    with mock.patch('requests.post') as post:
+        post.return_value.status_code = 200
+        post.return_value.json.return_value = {'situation': 'test'}
+        post.return_value.raise_for_status = lambda: None
+
+        result = generate_situation('http://server', 'cap', ['m1'], 'prompt')
+
+        post.assert_called_once_with(
+            'http://server/generate-situation',
+            json={'character_id': 'cap', 'memory_snippets': ['m1'], 'personality_prompt': 'prompt'}
+        )
+        assert result == 'test'

--- a/tickets.md
+++ b/tickets.md
@@ -35,3 +35,12 @@ Description: Define personalities.json schema, load personalities, map extension
 - [x] Documentation Written
 
 Description: Implement memory_logger.py to save per-character interaction logs and call it from call_handler.
+
+## T5 - Situation Engine
+- [x] Started
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
+
+Description: Add situation_generator module and integrate it with call_handler to request call context from the LLM server.


### PR DESCRIPTION
## Summary
- implement `situation_generator` for requesting call context from the LLM server
- integrate situation generation into `handle_call`
- extend unit tests for new behaviour
- record work on ticket **T5 - Situation Engine**

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e4f4efb48332a3fa65bcc6ab8cc5