### PR TITLE
Update planning docs and add future tickets

### DIFF
--- a/docs/planning.md
+++ b/docs/planning.md
@@ -21,12 +21,12 @@ This planning document defines the phases and milestones to guide development of
 **Goal:** Create basic AI loop using VAD, Whisper, LLM, and TTS
 
 ### Tasks:
-- [ ] `call_handler.py`: core handler script
-- [ ] `vad_recorder.py`: record speech naturally
-- [ ] `audio_player.py`: play WAV responses
+- [x] `call_handler.py`: core handler script
+- [x] `vad_recorder.py`: record speech naturally
+- [x] `audio_player.py`: play WAV responses
 - [ ] Add Whisper + TTS (local or remote)
-- [ ] Create `/process-audio` endpoint (Flask or FastAPI)
-- [ ] Test basic call → AI → response cycle
+- [x] Create `/process-audio` endpoint (Flask or FastAPI)
+- [x] Test basic call → AI → response cycle
 
 ---
 
@@ -34,13 +34,13 @@ This planning document defines the phases and milestones to guide development of
 **Goal:** Implement skydiving personalities with extensions and memory
 
 ### Tasks:
-- [ ] Define character schema (`personalities.json`)
-- [ ] Add unique extensions (701–705)
-- [ ] Add random personality logic for ext 1000
+- [x] Define character schema (`personalities.json`)
+- [x] Add unique extensions (701–705)
+- [x] Add random personality logic for ext 1000
 - [ ] Print-ready character card generation
 - [ ] Add initiative-based outbound call loop
-- [ ] Integrate `memory_logger.py`
-- [ ] Save memory log per character
+- [x] Integrate `memory_logger.py`
+- [x] Save memory log per character
 
 ---
 
@@ -49,8 +49,8 @@ This planning document defines the phases and milestones to guide development of
 
 ### Tasks:
 - [ ] Design prompt format
-- [ ] Implement `situation_generator.py`
-- [ ] Add call-start context logic to `call_handler.py`
+- [x] Implement `situation_generator.py`
+- [x] Add call-start context logic to `call_handler.py`
 - [ ] Use LLM to inject greeting mood/situation
 
 ---
@@ -59,7 +59,7 @@ This planning document defines the phases and milestones to guide development of
 **Goal:** Run all LLM interactions on local Ollama server
 
 ### Tasks:
-- [ ] Flask app with:
+- [x] Flask app with:
   - `/process-audio` – main AI loop
   - `/generate-situation` – scene builder
 - [ ] Add Whisper + LLM pipeline

--- a/tickets.md
+++ b/tickets.md
@@ -53,3 +53,66 @@ Description: Add situation_generator module and integrate it with call_handler t
 - [x] Documentation Written
 
 Description: Implement Flask backend API with `/process-audio` and `/generate-situation` endpoints.
+
+## T7 - Raspberry Pi & Asterisk Setup
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+Description: Install Raspberry Pi OS Lite, set up Asterisk with ATA and mini PBX, and verify trunk dial-out.
+
+## T8 - Whisper and TTS Integration
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+Description: Add Whisper transcription and text-to-speech support to the voice interface and processing server.
+
+## T9 - Character Card Generation
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+Description: Generate printable character cards from personalities.json for players.
+
+## T10 - Initiative-Based Outbound Calls
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+Description: Implement an outbound call loop that selects characters based on their initiative score.
+
+## T11 - Prompt Design and Greeting Logic
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+Description: Finalize prompt format and use the LLM to inject greeting mood and situations at call start.
+
+## T12 - Backend Pipeline and Security Enhancements
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+Description: Add Whisper and LLM pipeline, provide multiple TTS options, and secure the API endpoints for Raspberry Pi use.
+
+## T13 - Deployment and Polishing
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+Description: Create install script and systemd service, optimize TTS latency, finalize memory summarization, and perform final character recognition testing.


### PR DESCRIPTION
## Summary
- mark tasks in `planning.md` that are already implemented
- add new tickets for remaining work

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ecbc734483328a8d0529204662f2