### PR TITLE
Implement backend pipeline upgrades

### DIFF
--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -2,7 +2,10 @@
 
 This Flask application exposes two basic endpoints used by the phone firmware.
 
-- `/process-audio` accepts an uploaded WAV file, runs speech-to-text, and returns a synthesized WAV response. A `prompt` field may be supplied to steer the LLM. When the server is started with an API key, the header `X-API-Key` must be included.
+- `/process-audio` accepts an uploaded WAV file, runs speech-to-text via Whisper (if installed) and returns a synthesized WAV response. A `prompt` field may be supplied to steer the LLM. When the server is started with an API key, the header `X-API-Key` must be included.
 - `/generate-situation` returns a short text snippet describing a call situation based on the provided `character_id`.
 
+The speech-to-text step relies on the `whisper` library when installed. Text-to-speech falls back to a simple dummy engine but supports `espeak` and `pyttsx3` if available.
+
 The app is created via `src.api_server.create_app()` and can be launched with `python -m src.api_server`.
+`create_app` accepts optional `api_key` and `allowed_ips` arguments to restrict access.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,12 @@
+# Deployment Guide
+
+This project includes a helper script `install.sh` which sets up a Python virtual environment, installs dependencies and installs a systemd service file `ai-telephone.service`.
+
+To install on a Raspberry Pi:
+
+```bash
+./install.sh
+sudo systemctl start ai-telephone.service
+```
+
+The service will start the backend API on boot.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Simple installation helper
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+sudo cp systemd/ai-telephone.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable ai-telephone.service

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask
 webrtcvad
 sounddevice
 requests
+openai-whisper
+pyttsx3

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -9,13 +9,15 @@ from .stt import transcribe
 from .tts import synthesize
 
 
-def create_app(api_key: str | None = None) -> Flask:
+def create_app(api_key: str | None = None, allowed_ips: list[str] | None = None) -> Flask:
     """Return a configured Flask application."""
     app = Flask(__name__)
 
     def check_key() -> None:
         if api_key and request.headers.get("X-API-Key") != api_key:
             abort(401)
+        if allowed_ips and request.remote_addr not in allowed_ips:
+            abort(403)
 
     @app.post("/process-audio")
     def process_audio():

--- a/src/memory_logger.py
+++ b/src/memory_logger.py
@@ -41,3 +41,8 @@ def load_memory(memory_dir: Path, personality_id: str) -> List[Dict]:
     if file_path.exists():
         return json.loads(file_path.read_text())
     return []
+
+
+def summarize_memory(entries: List[Dict]) -> str:
+    """Return a simple summary string from saved memory entries."""
+    return " ".join(e.get("summary", "") for e in entries).strip()

--- a/src/stt.py
+++ b/src/stt.py
@@ -1,10 +1,25 @@
-"""Simple placeholder Speech-To-Text implementation."""
+"""Speech-To-Text utilities using Whisper when available."""
 from __future__ import annotations
 
 
+from tempfile import NamedTemporaryFile
+
+try:  # Optional heavy dependency
+    import whisper  # type: ignore
+except Exception:  # pragma: no cover - fallback when whisper missing
+    whisper = None
+
 def transcribe(audio_bytes: bytes) -> str:
-    """Return a dummy transcription for given audio bytes."""
-    # A real implementation would run Whisper or another STT engine here.
+    """Transcribe ``audio_bytes`` using Whisper if installed."""
     if not audio_bytes:
         return ""
-    return "beep"
+
+    if whisper is None:  # pragma: no cover - environment without whisper
+        return "beep"
+
+    with NamedTemporaryFile(suffix=".wav") as tmp:
+        tmp.write(audio_bytes)
+        tmp.flush()
+        model = whisper.load_model("base")
+        result = model.transcribe(tmp.name)
+        return result.get("text", "")

--- a/src/tts.py
+++ b/src/tts.py
@@ -1,8 +1,35 @@
-"""Simple placeholder Text-To-Speech implementation."""
+"""Text-To-Speech helpers with multiple backends."""
 from __future__ import annotations
 
+from tempfile import NamedTemporaryFile
+import subprocess
 
-def synthesize(text: str) -> bytes:
-    """Return dummy WAV bytes for given text."""
-    # A real implementation would call a TTS engine and return WAV data.
-    return text.encode("utf-8")
+try:  # optional dependency
+    import pyttsx3  # type: ignore
+except Exception:  # pragma: no cover - pyttsx3 may not be installed
+    pyttsx3 = None
+
+
+def synthesize(text: str, method: str = "dummy") -> bytes:
+    """Synthesize ``text`` to WAV bytes using ``method``.
+
+    Supported methods are ``dummy`` (return UTF‑8 bytes), ``espeak`` using the
+    ``espeak`` command, and ``pyttsx3`` when the library is available.
+    """
+
+    if method == "dummy":
+        return text.encode("utf-8")
+
+    if method == "espeak":
+        with NamedTemporaryFile(suffix=".wav") as tmp:
+            subprocess.run(["espeak", "-w", tmp.name, text], check=True)
+            return tmp.read()
+
+    if method == "pyttsx3" and pyttsx3 is not None:
+        engine = pyttsx3.init()
+        with NamedTemporaryFile(suffix=".wav") as tmp:
+            engine.save_to_file(text, tmp.name)
+            engine.runAndWait()
+            return tmp.read()
+
+    raise ValueError("Unknown TTS method")

--- a/systemd/ai-telephone.service
+++ b/systemd/ai-telephone.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=AI Telephone Backend
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 -m src.api_server
+WorkingDirectory=/opt/ai-telephone
+Restart=always
+User=pi
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_memory_logger.py
+++ b/tests/test_memory_logger.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from src.memory_logger import log_interaction, load_memory
+from src.memory_logger import log_interaction, load_memory, summarize_memory
 
 
 def test_log_and_load(tmp_path):
@@ -12,3 +12,4 @@ def test_log_and_load(tmp_path):
     assert len(data) == 2
     assert data[0]["caller_extension"] == "600"
     assert data[1]["summary"] == "bye"
+    assert summarize_memory(data) == "hi bye"

--- a/tests/test_stt_tts.py
+++ b/tests/test_stt_tts.py
@@ -1,12 +1,71 @@
-from src.stt import transcribe
-from src.tts import synthesize
+from unittest import mock
+
+from src import stt, tts
 
 
-def test_transcribe():
-    assert transcribe(b'data') == "beep"
-    assert transcribe(b'') == ""
+def test_transcribe_with_whisper():
+    model = mock.Mock()
+    model.transcribe.return_value = {"text": "hello"}
+    with mock.patch.object(stt, "whisper", mock.Mock(load_model=lambda name: model)):
+        assert stt.transcribe(b"data") == "hello"
 
 
-def test_synthesize():
-    data = synthesize("hi")
-    assert data == b"hi"
+def test_transcribe_empty():
+    assert stt.transcribe(b"") == ""
+
+
+def test_synthesize_dummy():
+    assert tts.synthesize("hi") == b"hi"
+
+
+def test_synthesize_espeak(monkeypatch):
+    class Dummy:
+        name = "tmp.wav"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def write(self, data):
+            pass
+
+        def flush(self):
+            pass
+
+        def read(self):
+            return b"espeak"
+
+    monkeypatch.setattr(tts, "NamedTemporaryFile", lambda suffix: Dummy())
+    monkeypatch.setattr(tts.subprocess, "run", lambda *a, **k: None)
+    assert tts.synthesize("hello", method="espeak") == b"espeak"
+
+
+def test_synthesize_pyttsx3(monkeypatch):
+    engine = mock.Mock()
+    monkeypatch.setattr(tts, "pyttsx3", mock.Mock(init=lambda: engine))
+
+    class Dummy:
+        name = "tmp.wav"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def write(self, data):
+            pass
+
+        def flush(self):
+            pass
+
+        def read(self):
+            return b"pyttsx3"
+
+    monkeypatch.setattr(tts, "NamedTemporaryFile", lambda suffix: Dummy())
+    out = tts.synthesize("hello", method="pyttsx3")
+    engine.save_to_file.assert_called_once()
+    engine.runAndWait.assert_called_once()
+    assert out == b"pyttsx3"

--- a/tickets.md
+++ b/tickets.md
@@ -109,19 +109,19 @@ Description: Finalize prompt format and use the LLM to inject greeting mood and 
 Description: Require an ``X-API-Key`` header for API calls when configured.
 
 ## T12 - Backend Pipeline and Security Enhancements
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+- [x] Started
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
 
 Description: Add Whisper and LLM pipeline, provide multiple TTS options, and secure the API endpoints for Raspberry Pi use.
 
 ## T13 - Deployment and Polishing
-- [ ] Started
+- [x] Started
 - [ ] Tests Written
 - [ ] Code Written
 - [ ] Tests Passed
-- [ ] Documentation Written
+- [x] Documentation Written
 
 Description: Create install script and systemd service, optimize TTS latency, finalize memory summarization, and perform final character recognition testing.


### PR DESCRIPTION
## Summary
- enhance backend API to check allowed IPs
- add whisper and multi-method TTS support
- provide helper functions to summarize memories
- add deployment script and service file
- document backend updates and deployment instructions
- test new backend and summarization functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874faae6ca88332989551fd8fd97d0f