### PR TITLE
Add bootstrap installer script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Bootstrap installer for AI Telephone
+# This script installs git, clones the repository and runs install.sh
+
+REPO_DIR=/opt/ai-telephone
+REPO_URL=https://github.com/wagskydive/ai-telephone.git
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run as root"
+    exit 1
+fi
+
+apt-get update
+apt-get install -y git
+
+if [ ! -d "$REPO_DIR" ]; then
+    git clone "$REPO_URL" "$REPO_DIR"
+else
+    git -C "$REPO_DIR" pull
+fi
+
+cd "$REPO_DIR"
+bash install.sh
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,24 +1,26 @@
 # Deployment Guide
 
-This project includes a helper script `install.sh` which can bootstrap a fresh
-Raspberry Pi. The script installs required packages, clones this repository into
-`/opt/ai-telephone` and installs a systemd service so the API starts on boot.
+This project includes two helper scripts. `bootstrap.sh` can be downloaded on a
+clean Raspberry Pi to clone the repository and run the installer automatically.
+`install.sh` lives inside the repository and sets up dependencies and the
+systemd service.
 
 ## Step-by-step guide
 
 1. **Flash Raspberry Pi OS Lite** using Raspberry Pi Imager. Enable SSH so the
    Pi can be accessed over the network.
-2. **Log in and download the installer**:
+2. **Log in and download the bootstrap installer**:
 
    ```bash
-   curl -L https://github.com/wagskydive/ai-telephone/raw/main/install.sh \
-       -o install.sh
-   sudo bash install.sh
+   curl -L https://github.com/wagskydive/ai-telephone/raw/main/bootstrap.sh \
+       -o bootstrap.sh
+   sudo bash bootstrap.sh
    ```
 
-   The script will install `git`, `python3-venv` and `asterisk`, clone the
-   repository to `/opt/ai-telephone`, create a virtual environment and register
-   the `ai-telephone.service` systemd unit.
+   This script installs `git`, clones the repository to `/opt/ai-telephone` and
+   then runs `install.sh` from that directory. `install.sh` creates the Python
+   virtual environment, installs dependencies and registers the
+   `ai-telephone.service` unit.
 3. **Start the service**:
 
    ```bash

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,5 @@
+def test_bootstrap_script_contents():
+    text = open('bootstrap.sh').read()
+    assert 'git clone' in text
+    assert 'bash install.sh' in text
+

--- a/tickets.md
+++ b/tickets.md
@@ -181,3 +181,12 @@ Description: Profile and reduce audio playback latency, ensuring snappy response
 - [ ] Documentation Written
 
 Description: Validate that each AI personality consistently identifies themselves during conversations.
+
+## T19 - Bootstrap Installer
+- [x] Started
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
+
+Description: Add bootstrap.sh that installs git, clones the repo and executes install.sh for one-command installation.


### PR DESCRIPTION
## Summary
- add `bootstrap.sh` to clone repo and run main installer
- update deployment guide for new script
- test `bootstrap.sh` exists and calls `install.sh`
- document new ticket for bootstrap installer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68750ce498b88332a25847f623b6c66b