### PR TITLE
Implement /process-text endpoint and improve robustness

### DIFF
--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -1,11 +1,13 @@
 # Backend API Server
 
-This Flask application exposes two basic endpoints used by the phone firmware.
+This Flask application exposes several endpoints used by the phone firmware.
 
 - `/process-audio` accepts an uploaded WAV file, runs speech-to-text via Whisper (if installed), sends the text and optional `prompt` to the LLM server, and returns a synthesized WAV response. When the server is started with an API key, the header `X-API-Key` must be included.
-- `/generate-situation` returns a short text snippet describing a call situation based on the provided `character_id`.
+- `/process-text` sends plain text and optional `prompt` to the LLM and returns synthesized speech.
+- `/generate-situation` builds a prompt from the provided `character_id`, optional memory snippets and personality prompt, then asks the LLM to return a short situation string.
 
 The speech-to-text step relies on the `whisper` library when installed. Text-to-speech falls back to a simple dummy engine but supports `espeak`, `pyttsx3`, an optional [ElevenLabs](https://elevenlabs.io) API backend, and a remote Chatterbox server when configured via `CHATTERBOX_URL`.
+Errors while contacting Whisper, the LLM server or a TTS backend are logged and result in an empty response with HTTP 500.
 
 The app is created via `src.api_server.create_app()` and can be launched with `python -m src.api_server`.
 `create_app` accepts optional `api_key` and `allowed_ips` arguments to restrict access.

--- a/src/llm.py
+++ b/src/llm.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 import os
 import requests
+import logging
 
 
 _DEFAULT_URL = os.environ.get("LLM_API_URL", "http://localhost:8001")
+
+logger = logging.getLogger(__name__)
 
 
 def generate_response(text: str, prompt: str | None = None, *, url: str | None = None) -> str:
@@ -14,7 +17,11 @@ def generate_response(text: str, prompt: str | None = None, *, url: str | None =
     payload = {"text": text}
     if prompt:
         payload["prompt"] = prompt
-    resp = requests.post(f"{target}/generate", json=payload)
-    resp.raise_for_status()
-    data = resp.json()
-    return data.get("response", "")
+    try:
+        resp = requests.post(f"{target}/generate", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("response", "")
+    except Exception:  # pragma: no cover - log failure and fallback
+        logger.exception("LLM request failed")
+        return ""

--- a/src/outbound.py
+++ b/src/outbound.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import random
 from typing import Callable, Iterable
+import time
+import logging
 
 from .personalities import Personality
 
@@ -16,3 +18,20 @@ def run_outbound(personalities: Iterable[Personality], originate: Callable[[int]
     """Trigger calls for selected personalities."""
     for p in select_personalities(personalities, rand):
         originate(p.extension)
+
+
+def outbound_loop(
+    personalities: Iterable[Personality],
+    originate: Callable[[int], None],
+    *,
+    interval: float = 60.0,
+    rand: Callable[[], float] = random.random,
+) -> None:
+    """Periodically invoke :func:`run_outbound`."""
+    logger = logging.getLogger(__name__)
+    while True:
+        try:
+            run_outbound(personalities, originate, rand=rand)
+        except Exception:  # pragma: no cover - log errors
+            logger.exception("outbound loop failed")
+        time.sleep(interval)

--- a/src/stt.py
+++ b/src/stt.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 
 from tempfile import NamedTemporaryFile
+import logging
+
+logger = logging.getLogger(__name__)
 
 try:  # Optional heavy dependency
     import whisper  # type: ignore
@@ -17,9 +20,13 @@ def transcribe(audio_bytes: bytes) -> str:
     if whisper is None:  # pragma: no cover - environment without whisper
         return "beep"
 
-    with NamedTemporaryFile(suffix=".wav") as tmp:
-        tmp.write(audio_bytes)
-        tmp.flush()
-        model = whisper.load_model("base")
-        result = model.transcribe(tmp.name)
-        return result.get("text", "")
+    try:
+        with NamedTemporaryFile(suffix=".wav") as tmp:
+            tmp.write(audio_bytes)
+            tmp.flush()
+            model = whisper.load_model("base")
+            result = model.transcribe(tmp.name)
+            return result.get("text", "")
+    except Exception:  # pragma: no cover - log failure and fallback
+        logger.exception("whisper failed")
+        return ""

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -28,9 +28,38 @@ def test_process_audio():
 def test_generate_situation():
     app = create_app()
     client = app.test_client()
-    response = client.post("/generate-situation", json={"character_id": "cap"})
-    assert response.status_code == 200
-    assert response.get_json()["situation"] == "situation for cap"
+    with mock.patch(
+        "src.api_server.generate_response", return_value="scene"
+    ) as gen:
+        resp = client.post(
+            "/generate-situation",
+            json={
+                "character_id": "cap",
+                "memory_snippets": ["m"],
+                "personality_prompt": "p",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["situation"] == "scene"
+        gen.assert_called_once()
+
+
+def test_process_text():
+    app = create_app()
+    client = app.test_client()
+    with mock.patch(
+        "src.api_server.generate_response", return_value="r"
+    ) as llm, mock.patch(
+        "src.api_server.synthesize", return_value=b"wav"
+    ) as syn:
+        resp = client.post(
+            "/process-text",
+            json={"text": "hi", "prompt": "p"},
+        )
+        assert resp.status_code == 200
+        assert resp.data == b"wav"
+        llm.assert_called_once_with("hi", "p")
+        syn.assert_called_once_with("r")
 
 
 def test_api_key_required():

--- a/tests/test_stt_tts.py
+++ b/tests/test_stt_tts.py
@@ -11,6 +11,12 @@ def test_transcribe_with_whisper():
         assert stt.transcribe(b"data") == "hello"
 
 
+def test_transcribe_whisper_failure():
+    with mock.patch.object(stt, "whisper", mock.Mock(load_model=lambda n: (_ for _ in ()).throw(RuntimeError))):
+        out = stt.transcribe(b"data")
+        assert out == ""
+
+
 def test_transcribe_empty():
     assert stt.transcribe(b"") == ""
 

--- a/tickets.md
+++ b/tickets.md
@@ -211,9 +211,18 @@ Description: Add Chatterbox TTS backend with fallback handling.
 
 ## T22 - Further Development Tasks
 - [x] Started
- - [ ] Tests Written
- - [ ] Code Written
- - [ ] Tests Passed
- - [ ] Documentation Written
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
 
 Description: Begin implementing items listed in further_development.md.
+
+## T23 - Outbound Call History Check
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+Description: Prevent characters from repeatedly calling the same extension by keeping a short call history and skipping recently dialed numbers.


### PR DESCRIPTION
## Summary
- add `/process-text` endpoint to the Flask API
- generate situations using the LLM server
- wrap audio handling and LLM calls in error handlers with logging
- provide an outbound call loop helper
- document new endpoints and error behaviour
- update tests and tickets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687531050b7083329a77db1dcf8dca18