### PR TITLE
Implement personality disable and log pruning

### DIFF
--- a/data/personalities.json
+++ b/data/personalities.json
@@ -5,7 +5,8 @@
     "extension": 701,
     "initiative": 0.9,
     "tagline": "Yell something and brace for chaos.",
-    "prompt": "Your name is Captain Freefall. You're a fearless, loud, overly confident ex-military skydiver who speaks in motivational shouts."
+    "prompt": "Your name is Captain Freefall. You're a fearless, loud, overly confident ex-military skydiver who speaks in motivational shouts.",
+    "enabled": true
   },
   {
     "id": "sky_jester",
@@ -13,7 +14,8 @@
     "extension": 702,
     "initiative": 0.5,
     "tagline": "The prankster of the skies.",
-    "prompt": "Your name is Sky Jester. You love making jokes while floating through the air and never miss a chance to prank other jumpers."
+    "prompt": "Your name is Sky Jester. You love making jokes while floating through the air and never miss a chance to prank other jumpers.",
+    "enabled": true
   },
   {
     "id": "professor_parachute",
@@ -21,6 +23,7 @@
     "extension": 703,
     "initiative": 0.2,
     "tagline": "Always has a lesson about terminal velocity.",
-    "prompt": "Your name is Professor Parachute. A scholarly expert on skydiving physics who can't help explaining concepts mid-conversation."
+    "prompt": "Your name is Professor Parachute. A scholarly expert on skydiving physics who can't help explaining concepts mid-conversation.",
+    "enabled": true
   }
 ]

--- a/docs/further_development.md
+++ b/docs/further_development.md
@@ -18,8 +18,8 @@ This document outlines prioritized enhancements and cleanup tasks to improve and
 ## 🥈 Medium Priority
 
 - [ ] 🔄 Add history check to prevent characters calling same extension too often
-- [ ] 🔄 Add ability to pause or disable individual personalities from calling
-- [ ] 🔄 Expand `log_interaction()` to prune after N entries or rotate logs
+- [x] 🔄 Add ability to pause or disable individual personalities from calling
+- [x] 🔄 Expand `log_interaction()` to prune after N entries or rotate logs
 - [ ] 🔄 Add inferred name guessing logic to prompt/summary pipeline
 - [ ] 🔄 Improve error handling in API server (e.g. malformed audio, missing fields)
 

--- a/docs/outbound_calls.md
+++ b/docs/outbound_calls.md
@@ -10,3 +10,6 @@ from src.personalities import load_personalities
 personalities = load_personalities(Path('data/personalities.json'))
 run_outbound(personalities, originate=lambda ext: print(f'call {ext}'))
 ```
+
+Set ``enabled`` to ``false`` in ``personalities.json`` to temporarily exclude a
+character from outbound calls.

--- a/src/memory_logger.py
+++ b/src/memory_logger.py
@@ -15,8 +15,13 @@ def log_interaction(
     summary: str,
     name_guess: str,
     quotes: List[str],
+    max_entries: int | None = None,
 ) -> None:
-    """Append an interaction entry for the given personality."""
+    """Append an interaction entry for the given personality.
+
+    When ``max_entries`` is provided, only the most recent entries up to that
+    limit are retained on disk.
+    """
     memory_dir.mkdir(parents=True, exist_ok=True)
     file_path = memory_dir / f"{personality_id}.json"
     if file_path.exists():
@@ -32,6 +37,8 @@ def log_interaction(
             "quotes": quotes,
         }
     )
+    if max_entries is not None and len(data) > max_entries:
+        data = data[-max_entries:]
     file_path.write_text(json.dumps(data, indent=2))
 
 

--- a/src/outbound.py
+++ b/src/outbound.py
@@ -9,9 +9,18 @@ import logging
 from .personalities import Personality
 
 
-def select_personalities(personalities: Iterable[Personality], rand: Callable[[], float] = random.random) -> list[Personality]:
+def select_personalities(
+    personalities: Iterable[Personality],
+    rand: Callable[[], float] = random.random,
+) -> list[Personality]:
     """Return personalities chosen to place outbound calls."""
-    return [p for p in personalities if rand() < p.initiative]
+    selected = []
+    for p in personalities:
+        if not p.enabled:
+            continue
+        if rand() < p.initiative:
+            selected.append(p)
+    return selected
 
 
 def run_outbound(personalities: Iterable[Personality], originate: Callable[[int], None], rand: Callable[[], float] = random.random) -> None:

--- a/src/personalities.py
+++ b/src/personalities.py
@@ -17,12 +17,18 @@ class Personality:
     initiative: float
     tagline: str
     prompt: str
+    enabled: bool = True
 
 
 def load_personalities(file_path: Path) -> list[Personality]:
     """Load personalities from a JSON file."""
     data = json.loads(file_path.read_text())
-    return [Personality(**entry) for entry in data]
+    personalities: list[Personality] = []
+    for entry in data:
+        if "enabled" not in entry:
+            entry["enabled"] = True
+        personalities.append(Personality(**entry))
+    return personalities
 
 
 def get_by_extension(personalities: list[Personality], extension: int) -> Personality:

--- a/tests/test_memory_logger.py
+++ b/tests/test_memory_logger.py
@@ -15,3 +15,21 @@ def test_log_and_load(tmp_path):
     assert summarize_memory(data) == "hi; bye"
     # limit should restrict entries
     assert summarize_memory(data, limit=1) == "bye"
+
+
+def test_log_pruning(tmp_path):
+    memory_dir = tmp_path / "mem"
+    for i in range(5):
+        log_interaction(
+            memory_dir,
+            "p",
+            caller_extension=str(i),
+            summary=str(i),
+            name_guess="",
+            quotes=[],
+            max_entries=3,
+        )
+
+    data = load_memory(memory_dir, "p")
+    # Should keep only last three entries
+    assert [d["summary"] for d in data] == ["2", "3", "4"]

--- a/tests/test_outbound.py
+++ b/tests/test_outbound.py
@@ -9,6 +9,15 @@ def test_select_personalities():
     assert selected == [pers[0]]
 
 
+def test_disabled_personalities():
+    pers = [
+        Personality("a", "A", 1, 0.9, "t", "p", enabled=False),
+        Personality("b", "B", 2, 0.9, "t", "p"),
+    ]
+    selected = select_personalities(pers, rand=lambda: 0.1)
+    assert selected == [pers[1]]
+
+
 def test_run_outbound():
     pers = [Personality("a", "A", 1, 0.9, "t", "p")]
     calls = []

--- a/tickets.md
+++ b/tickets.md
@@ -263,20 +263,20 @@ Description: Wrap `record_until_silence()` and LLM requests in `try/except` bloc
 Description: Increase logging detail in `call_handler.py` and `api_server.py` for easier debugging.
 
 ## T28 - Personality Pause/Disable
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+- [x] Started
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
 
 Description: Add ability to pause or disable individual personalities from making outbound calls.
 
 ## T29 - Log Pruning
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+- [x] Started
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
 
 Description: Expand `log_interaction()` to prune logs after a set number of entries or rotate log files.
 


### PR DESCRIPTION
## Summary
- allow personalities to be disabled via new `enabled` field
- skip disabled personalities when selecting outbound calls
- prune memory logs using new `max_entries` option
- document outbound disable flag
- update further development checklist
- update tests and tickets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687539c531708332aca571ae11317c98